### PR TITLE
remove BS and update JS

### DIFF
--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -42,14 +42,17 @@ class TestResourceSpectrum(unittest.TestCase):
     
     def test_pierson_moskowitz_spectrum(self):
         S = wave.resource.pierson_moskowitz_spectrum(self.f,self.Tp,self.Hs)
+        Hm0 = wave.resource.significant_wave_height(S).iloc[0,0]
         Tp0 = wave.resource.peak_period(S).iloc[0,0]
         
-        error = np.abs(self.Tp - Tp0)/self.Tp
+        errorHm0 = np.abs(self.Tp - Tp0)/self.Tp
+        errorTp0 = np.abs(self.Hs - Hm0)/self.Hs
         
-        self.assertLess(error, 0.01)
-        
-    def test_bretschneider_spectrum(self):
-        S = wave.resource.bretschneider_spectrum(self.f,self.Tp,self.Hs)
+        self.assertLess(errorHm0, 0.01)
+        self.assertLess(errorTp0, 0.01)
+
+    def test_jonswap_spectrum(self):
+        S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
         Hm0 = wave.resource.significant_wave_height(S).iloc[0,0]
         Tp0 = wave.resource.peak_period(S).iloc[0,0]
         
@@ -144,17 +147,6 @@ class TestResourceSpectrum(unittest.TestCase):
         rmse_sum = (np.sum(rmse)/len(rmse))**0.5
 
         self.assertLess(rmse_sum, 0.02)
-    
-    def test_jonswap_spectrum(self):
-        S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
-        Hm0 = wave.resource.significant_wave_height(S).iloc[0,0]
-        Tp0 = wave.resource.peak_period(S).iloc[0,0]
-        
-        errorHm0 = np.abs(self.Tp - Tp0)/self.Tp
-        errorTp0 = np.abs(self.Hs - Hm0)/self.Hs
-        
-        self.assertLess(errorHm0, 0.01)
-        self.assertLess(errorTp0, 0.01)
     
     def test_plot_spectrum(self):            
         filename = abspath(join(testdir, 'wave_plot_spectrum.png'))

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -65,7 +65,7 @@ def elevation_spectrum(eta, sample_rate, nnft, window='hann', detrend=True, nove
 
 def pierson_moskowitz_spectrum(f, Tp, Hs):
     """
-    Calculates Pierson-Moskowitz Spectrum from Tucker and Pitt (2001) 
+    Calculates Pierson-Moskowitz Spectrum from IEC TS 62600-2 ED2 Annex C.2 (2019)
     
     Parameters
     ------------
@@ -103,7 +103,7 @@ def pierson_moskowitz_spectrum(f, Tp, Hs):
 
 def jonswap_spectrum(f, Tp, Hs, gamma=None):
     """
-    Calculates JONSWAP spectrum from Hasselmann et al (1973)
+    Calculates JONSWAP Spectrum from IEC TS 62600-2 ED2 Annex C.2 (2019)
     
     Parameters
     ------------

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -91,52 +91,13 @@ def pierson_moskowitz_spectrum(f, Tp, Hs):
     assert isinstance(Hs, (int,float)), 'Hs must be of type int or float'
     
     f.sort()
-    g = 9.81   
     B_PM = (5/4)*(1/Tp)**4
-    #A_PM = 0.0081*g**2*(2*np.pi)**(-4)
     A_PM = B_PM*(Hs/2)**2
     Sf  = A_PM*f**(-5)*np.exp(-B_PM*f**(-4)) 
      
     col_name = 'Pierson-Moskowitz ('+str(Tp)+'s)'
     S = pd.DataFrame(Sf, index=f, columns=[col_name])    
 
-    return S
-
-def bretschneider_spectrum(f, Tp, Hs):
-    """
-    Calculates Bretschneider Sprectrum from Tucker and Pitt (2001)
-    
-    Parameters
-    ------------
-    f: numpy array
-        Frequency [Hz]
-    Tp: float/int
-        Peak period [s]
-    Hs: float/int
-        Significant wave height [m]        
-    
-    Returns
-    ---------    
-    S: pandas DataFrame
-        Spectral density [m^2/Hz] indexed by frequency [Hz]
-
-    """
-    try:
-        f = np.array(f)
-    except:
-        pass
-    assert isinstance(f, np.ndarray), 'f must be of type np.ndarray'
-    assert isinstance(Tp, (int,float)), 'Tp must be of type int or float'
-    assert isinstance(Hs, (int,float)), 'Hs must be of type int or float'
-
-    f.sort()
-    B_BS = (1.057/Tp)**4
-    A_BS = B_BS*(Hs/2)**2
-    Sf = A_BS*f**(-5)*np.exp(-B_BS*f**(-4))        
-
-    col_name = 'Bretschneider ('+str(Hs)+'m,'+str(Tp)+'s)'
-    S = pd.DataFrame(Sf, index=f, columns=[col_name])    
-    
     return S
 
 
@@ -172,7 +133,9 @@ def jonswap_spectrum(f, Tp, Hs, gamma=None):
         'gamma must be of type int or float'
 
     f.sort()    
-    g = 9.81 
+    B_PM = (5/4)*(1/Tp)**4
+    A_PM = B_PM*(Hs/2)**2
+    S_f  = A_PM*f**(-5)*np.exp(-B_PM*f**(-4)) 
     
     if not gamma:
         TpsqrtHs = Tp/np.sqrt(Hs);
@@ -181,7 +144,7 @@ def jonswap_spectrum(f, Tp, Hs, gamma=None):
         elif TpsqrtHs > 5:
             gamma = 1;
         else:
-            gamma = exp(5.75 - 1.15*TpsqrtHs);
+            gamma = np.exp(5.75 - 1.15*TpsqrtHs);
         
     # Cutoff frequencies for gamma function
     siga = 0.07 
@@ -193,9 +156,8 @@ def jonswap_spectrum(f, Tp, Hs, gamma=None):
     Gf = np.zeros(f.shape)
     Gf[lind] = gamma**np.exp(-(f[lind]-fp)**2/(2*siga**2*fp**2))
     Gf[hind] = gamma**np.exp(-(f[hind]-fp)**2/(2*sigb**2*fp**2))
-    S_temp = g**2*(2*np.pi)**(-4)*f**(-5)*np.exp(-(5/4)*(f/fp)**(-4))
-    alpha_JS = Hs**(2)/16/np.trapz(S_temp*Gf,f)
-    Sf = alpha_JS*S_temp*Gf # Wave Spectrum [m^2-s] 
+    C = 1- 0.287*np.log(gamma)
+    Sf = C*S_f*Gf
     
     col_name = 'JONSWAP ('+str(Hs)+'m,'+str(Tp)+'s)'
     S = pd.DataFrame(Sf, index=f, columns=[col_name])  


### PR DESCRIPTION
@ssolson this PR into your fork does the following for consistency with IEC TC114 -2 Annex C (and WEC-Sim https://github.com/WEC-Sim/WEC-Sim/pull/365):
- removes the Bretschneider (BS) spectrum, in this form it is a duplication of the Pierson-Moskowitz (PM) spectrum 
- minor updates to the JONSWAP (JS) spectrum so that it is more clearly an expansion of the PM spectrum, per IEC TC 114 -2 Annex C. 
- updates the BS tests to include Hs, since its definition is now a function of both Tp and Hs